### PR TITLE
Fixes #5 Set publish CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish to NPM
+
+on:
+  push:
+    branches:
+      - master
+      - v[0-9]+
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  publish:
+    name: Run with Node.js '12'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          version: ${{ matrix.node-version }}
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directus/gatsby-source-directus",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "A Gatsby source plugin to pull content from a Directus CMS backend.",
   "main": "./dist/gatsby-node.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-source-directus",
+  "name": "@directus/gatsby-source-directus",
   "version": "1.0.0",
   "description": "A Gatsby source plugin to pull content from a Directus CMS backend.",
   "main": "./dist/gatsby-node.js",


### PR DESCRIPTION
This PR set the package name to `@directus/gatsby-source-directus` and add a publish workflow.

Before merging we need to set the `NPM_TOKEN` for this repo.

Fixes #5